### PR TITLE
Assert partial flag and document handling

### DIFF
--- a/docs/powerbi_m_example.m
+++ b/docs/powerbi_m_example.m
@@ -5,6 +5,8 @@ let
     url = baseUrl & "?from=" & fromDate & "&to=" & toDate & "&pageSize=1000",
     source = Web.Contents(url, [Timeout=#duration(0,0,2,0)]),
     json = Json.Document(source),
+    partial = if Record.HasFields(json, "partial") then json[partial] else true,
+    _ = if partial then error "partial response" else null,
     rows = Table.FromList(json[rows], Splitter.SplitByNothing(), null, null, ExtraValues.Error)
 in
     rows

--- a/docs/render.md
+++ b/docs/render.md
@@ -17,6 +17,12 @@ uvicorn main:app --host 0.0.0.0 --port $PORT --workers 2
 ## Logs
 Use the Render dashboard or `render logs` CLI. Each request includes `X-Request-ID`.
 
+## Partial responses
+The `exportar` endpoint may return a JSON response with a boolean `partial` flag.
+Clients must verify that `partial` is `false` before using the data and should
+retry later if it is `true`. See `powerbi_m_example.m` for an example of failing
+early when a partial response is encountered.
+
 ## Common issues
 - CORS 4xx: check `ALLOWED_ORIGINS`.
 - 413 payload: result too large, lower `pageSize`.

--- a/scripts/prod_probe.py
+++ b/scripts/prod_probe.py
@@ -38,9 +38,10 @@ def main() -> int:
         print("exportar status", resp.status_code, file=sys.stderr)
         return 1
     data = resp.json()
+    assert data.get("partial") is False, f"partial flag is {data.get('partial')!r}"
     rows = data.get("rows", [])
-    if data.get("partial") or not rows:
-        print("partial or empty", file=sys.stderr)
+    if not rows:
+        print("empty", file=sys.stderr)
         return 1
     print(json.dumps({"rows": len(rows), "duration_ms": int(duration * 1000)}))
     return 0


### PR DESCRIPTION
## Summary
- assert `partial` flag in production probe
- document `partial` flag in Render deployment guide
- show Power BI example that errors on `partial`

## Testing
- `pytest` *(fails: HTTPSConnectionPool(host='dashmarketing.onrender.com', port=443): Max retries exceeded with url: /health)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e9dc96508332b66261305e37f582