### PR TITLE
Ensure aggregate totals reuse detail filters

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,11 +116,13 @@ def _month_range_iter(start: dt.date, end: dt.date) -> List[dt.date]:
         cur = dt.date(year, month, 1)
     return out
 
-def _agg_totals(client: BetaAnalyticsDataClient, start_iso: str, end_iso: str) -> Dict[str, float]:
+def _agg_totals(client: BetaAnalyticsDataClient, detail_req: RunReportRequest) -> Dict[str, float]:
     names = ["sessions", "activeUsers", "screenPageViews", "conversions", "totalRevenue"]
     req = RunReportRequest(
-        property=f"properties/{PROPERTY_ID}",
-        date_ranges=[DateRange(start_date=start_iso, end_date=end_iso)],
+        property=detail_req.property,
+        date_ranges=detail_req.date_ranges,
+        dimension_filter=detail_req.dimension_filter,
+        metric_filter=detail_req.metric_filter,
         dimensions=[],
         metrics=[Metric(name=m) for m in names],
         limit=1,
@@ -288,7 +290,7 @@ def exportar_datos(request: Request, params: ExportarParams = Depends()):
             partial = True
             reason = "ga4_limit"
 
-        agg = _agg_totals(client, s_iso, e_iso)
+        agg = _agg_totals(client, req)
         diff = {
             "sessions": _pct_diff(sum_sessions, agg.get("sessions", 0.0)),
             "activeUsers": _pct_diff(sum_users, agg.get("activeUsers", 0.0)),
@@ -346,6 +348,12 @@ def exportar_mensual(request: Request, params: ExportarMensualParams = Depends()
     client = _ga4_client()
     dims = _dims()
     mets = _mets()
+    detail_req = RunReportRequest(
+        property=f"properties/{PROPERTY_ID}",
+        date_ranges=[DateRange(start_date=s_iso, end_date=e_iso)],
+        dimensions=dims,
+        metrics=mets,
+    )
 
     pages_total = 0
     sum_sessions = sum_users = sum_views = sum_conv = sum_rev = 0.0
@@ -410,7 +418,7 @@ def exportar_mensual(request: Request, params: ExportarMensualParams = Depends()
 
         yield b"],"
 
-        agg = _agg_totals(client, s_iso, e_iso)
+        agg = _agg_totals(client, detail_req)
         diff = {
             "sessions": _pct_diff(sum_sessions, agg.get("sessions", 0.0)),
             "activeUsers": _pct_diff(sum_users, agg.get("activeUsers", 0.0)),

--- a/tests/test_agg_totals.py
+++ b/tests/test_agg_totals.py
@@ -1,0 +1,69 @@
+import pathlib, sys
+from google.analytics.data_v1beta.types import RunReportRequest, DateRange, Dimension, Metric, FilterExpression, Filter
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from main import _agg_totals
+
+
+class _FakeMetricValue:
+    def __init__(self, value):
+        self.value = str(value)
+
+
+class _FakeRow:
+    def __init__(self, values):
+        self.metric_values = [_FakeMetricValue(v) for v in values]
+
+
+class _FakeResp:
+    def __init__(self, values):
+        self.rows = [_FakeRow(values)]
+
+
+class _FakeClient:
+    def __init__(self, resp):
+        self._resp = resp
+        self.last_req = None
+
+    def run_report(self, req, timeout=None):
+        self.last_req = req
+        return self._resp
+
+
+def test_agg_totals_matches_detail_sum():
+    detail_rows = [
+        {"sessions": 10, "activeUsers": 5},
+        {"sessions": 20, "activeUsers": 7},
+    ]
+    totals = {
+        "sessions": sum(r["sessions"] for r in detail_rows),
+        "activeUsers": sum(r["activeUsers"] for r in detail_rows),
+        "screenPageViews": 0.0,
+        "conversions": 0.0,
+        "totalRevenue": 0.0,
+    }
+
+    resp = _FakeResp([totals[m] for m in [
+        "sessions",
+        "activeUsers",
+        "screenPageViews",
+        "conversions",
+        "totalRevenue",
+    ]])
+    client = _FakeClient(resp)
+
+    detail_req = RunReportRequest(
+        property="properties/123",
+        date_ranges=[DateRange(start_date="2024-01-01", end_date="2024-01-31")],
+        dimensions=[Dimension(name="city")],
+        metrics=[Metric(name="sessions"), Metric(name="activeUsers")],
+        dimension_filter=FilterExpression(
+            filter=Filter(field_name="city", string_filter=Filter.StringFilter(value="London"))
+        ),
+    )
+
+    agg = _agg_totals(client, detail_req)
+    assert agg == totals
+    assert client.last_req.dimension_filter == detail_req.dimension_filter
+    assert client.last_req.date_ranges == detail_req.date_ranges
+    assert client.last_req.dimensions == []


### PR DESCRIPTION
## Summary
- Use detail request's dimensions and filters when computing aggregate totals
- Add unit test validating totals match summed detail rows

## Testing
- `pytest -m "not e2e" -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e9db1a148332a5206b17aed83632