### PR TITLE
Allow unlimited export pagination

### DIFF
--- a/docs/render.md
+++ b/docs/render.md
@@ -22,6 +22,8 @@ Use the Render dashboard or `render logs` CLI. Each request includes `X-Request-
 - 413 payload: result too large, lower `pageSize`.
 - 502/504: upstream timeout; view GA4 quotas.
 - Cold starts on free plan may exceed 50s.
+- Large exports stream until GA4 `rowCount` is exhausted. Use `maxPages` query
+  parameter to set an optional safety cap.
 
 ## Corporate proxy / 403 tunnel
 If you see `ProxyError('Tunnel connection failed: 403 Forbidden')` when running probes:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,13 @@ import os
 import datetime as dt
 import pytest
 import requests
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+from types import SimpleNamespace
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import main
 
 BASE_URL = os.getenv("BASE_URL", "https://dashmarketing.onrender.com").rstrip("/")
 
@@ -32,3 +39,38 @@ def test_exportar() -> None:
     data = r.json()
     assert not data.get("partial")
     assert len(data.get("rows", [])) > 0
+
+
+def test_exportar_many_pages_no_partial() -> None:
+    client = TestClient(main.app)
+
+    def fake_run_report(client_param, req, rid):
+        if getattr(req, "offset", 0) >= 205:
+            return SimpleNamespace(rows=[], row_count=205, next_page_token=None)
+        return SimpleNamespace(rows=[object()], row_count=205, next_page_token=None)
+
+    DummyReq = lambda **kwargs: SimpleNamespace(page_token=None, offset=0)
+
+    with patch("main._ga4_client", return_value=None), \
+        patch("main._run_report", side_effect=fake_run_report), \
+        patch("main._row_to_dict", return_value={"sessions": 1}), \
+        patch("main._agg_totals", return_value={"sessions": 205, "activeUsers": 0, "screenPageViews": 0, "conversions": 0, "totalRevenue": 0}), \
+        patch("main.time.sleep", return_value=None), \
+        patch("main.RunReportRequest", DummyReq), \
+        patch("main._dims", return_value=[]), \
+        patch("main._mets", return_value=[]):
+        r = client.get(
+            "/exportar",
+            params={
+                "from": "2024-01-01",
+                "start": "2024-01-01",
+                "to": "2024-01-31",
+                "end": "2024-01-31",
+                "pageSize": 1,
+            },
+        )
+        assert r.status_code == 200
+        txt = r.text
+        assert txt.count('{"sessions":1}') == 205
+        assert '"pages":205' in txt
+        assert '"partial":false' in txt


### PR DESCRIPTION
## Summary
- remove hard pagination cap and continue until GA4 rowCount is consumed
- document unlimited pagination and optional `maxPages` cap
- add test covering large exports and ensure `partial` is false

## Testing
- `pytest -k "not e2e" -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4e9da40b48332a078b8f34c3f6730