### PR TITLE
Allow unlimited export pagination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+ENV=production
+ALLOWED_ORIGINS=http://localhost:3000,https://dashmarketing.onrender.com
+GA4_PROPERTY_ID=<TU_GA4_PROPERTY_ID>
+GA4_JSON_KEY_PATH=/etc/secrets/ga4-credentials.json
+GA4_TIMEOUT_SECONDS=60
+GA4_MAX_RETRIES=3
+GOOGLE_ADS_YAML_PATH=/etc/secrets/google-ads.yaml

--- a/docs/powerbi_m_example.m
+++ b/docs/powerbi_m_example.m
@@ -1,0 +1,10 @@
+let
+    baseUrl = "https://dashmarketing.onrender.com/exportar",
+    fromDate = Date.ToText(Date.AddDays(DateTimeZone.UtcNow(), -30), "yyyy-MM-dd"),
+    toDate = Date.ToText(DateTimeZone.UtcNow(), "yyyy-MM-dd"),
+    url = baseUrl & "?from=" & fromDate & "&to=" & toDate & "&pageSize=1000&maxPages=10000",
+    source = Web.Contents(url, [Timeout=#duration(0,0,2,0)]),
+    json = Json.Document(source),
+    rows = Table.FromList(json[rows], Splitter.SplitByNothing(), null, null, ExtraValues.Error)
+in
+    rows

--- a/docs/render.md
+++ b/docs/render.md
@@ -1,0 +1,33 @@
+# Render deployment
+
+## Environment variables
+- `ENV` – set to `production`
+- `ALLOWED_ORIGINS` – comma separated list of allowed CORS origins
+- `GA4_PROPERTY_ID`
+- `GA4_JSON_KEY_PATH` or `GA4_JSON_KEY_BASE64`
+- `GA4_TIMEOUT_SECONDS`
+- `GA4_MAX_RETRIES`
+- `GOOGLE_ADS_YAML_PATH`
+
+## Start command
+```
+uvicorn main:app --host 0.0.0.0 --port $PORT --workers 2
+```
+
+## Logs
+Use the Render dashboard or `render logs` CLI. Each request includes `X-Request-ID`.
+
+## Common issues
+- CORS 4xx: check `ALLOWED_ORIGINS`.
+- 413 payload: result too large, lower `pageSize`.
+- 502/504: upstream timeout; view GA4 quotas.
+- Cold starts on free plan may exceed 50s.
+- `partial=true`: raise `maxPages` or shrink date range.
+
+## Corporate proxy / 403 tunnel
+If you see `ProxyError('Tunnel connection failed: 403 Forbidden')` when running probes:
+1. Export NO_PROXY to bypass the system proxy:
+   - Bash/macOS: `export NO_PROXY=localhost,127.0.0.1,.onrender.com`
+   - PowerShell: `$env:NO_PROXY="localhost,127.0.0.1,.onrender.com"`
+2. Or simply run the probes (they already ignore proxies in code):
+   `python scripts/prod_probe.py`

--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
-import os, json, time, logging, datetime as dt
+import os, json, time, logging, datetime as dt, uuid, base64, random
 from typing import List, Dict, Any, Optional, Tuple, Iterable
 
-from fastapi import FastAPI, Query, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse, PlainTextResponse
+from pydantic import BaseModel, Field, ConfigDict
+
+from dotenv import load_dotenv
 
 from google.oauth2 import service_account
 from google.analytics.data_v1beta import BetaAnalyticsDataClient
@@ -12,6 +15,8 @@ from google.analytics.data_v1beta.types import (
 )
 
 # ------------------------------ Config ---------------------------------------
+load_dotenv()
+
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
     format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
@@ -24,24 +29,38 @@ def _dumps(obj) -> bytes:
 
 app = FastAPI(title="Dash Marketing API", version="1.2.1")
 
+ENV = os.getenv("ENV", "development")
+allowed_origins = [o.strip() for o in os.getenv("ALLOWED_ORIGINS", "").split(",") if o.strip()]
+if not allowed_origins:
+    allowed_origins = ["*"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=os.getenv("CORS_ALLOW_ORIGINS", "*").split(","),
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
 PROPERTY_ID = os.getenv("GA4_PROPERTY_ID", "279889272")
-CREDENTIALS_FILE = os.getenv("GA4_CREDENTIALS_FILE", "/etc/secrets/ga4-credentials.json")
+GA4_JSON_KEY_PATH = os.getenv("GA4_JSON_KEY_PATH", "/etc/secrets/ga4-credentials.json")
+GA4_JSON_KEY_BASE64 = os.getenv("GA4_JSON_KEY_BASE64")
 MIN_START_DATE = dt.date(2024, 1, 1)
+GA4_TIMEOUT_SECONDS = float(os.getenv("GA4_TIMEOUT_SECONDS", "60"))
+GA4_MAX_RETRIES = int(os.getenv("GA4_MAX_RETRIES", "3"))
 
 # ------------------------------ Utils ----------------------------------------
 def _ga4_client() -> BetaAnalyticsDataClient:
-    if not os.path.exists(CREDENTIALS_FILE):
-        raise FileNotFoundError(f"GA4 credentials not found at {CREDENTIALS_FILE}")
-    with open(CREDENTIALS_FILE, "r") as fh:
-        info = json.load(fh)
+    info: Dict[str, Any]
+    if GA4_JSON_KEY_BASE64:
+        info = json.loads(base64.b64decode(GA4_JSON_KEY_BASE64))
+    else:
+        path = GA4_JSON_KEY_PATH or "/etc/secrets/ga4-credentials.json"
+        if not os.path.exists(path):
+            path = "/etc/secrets/ga4-credentials.json"
+        if not os.path.exists(path):
+            raise HTTPException(status_code=500, detail=f"GA4 credentials not found at {path}")
+        with open(path, "r") as fh:
+            info = json.load(fh)
     creds = service_account.Credentials.from_service_account_info(info)
     return BetaAnalyticsDataClient(credentials=creds)
 
@@ -126,44 +145,87 @@ def _row_to_dict(row, dims: List[Dimension], mets: List[Metric]) -> Dict[str, An
 def _pct_diff(a: float, b: float) -> float:
     return 0.0 if (b or 0.0) == 0.0 else (a - b) / b
 
+
+# ------------------------------ Middleware -----------------------------------
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    rid = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+    start = time.time()
+    request.state.request_id = rid
+    response = await call_next(request)
+    duration = time.time() - start
+    log.info("%s %s %s %d %.3fs", rid, request.method, request.url.path, response.status_code, duration)
+    response.headers["X-Request-ID"] = rid
+    return response
+
+
+# ------------------------------ Retries --------------------------------------
+def _run_report(client: BetaAnalyticsDataClient, req: RunReportRequest, request_id: str):
+    for attempt in range(1, GA4_MAX_RETRIES + 1):
+        try:
+            resp = client.run_report(req, timeout=GA4_TIMEOUT_SECONDS)
+            log.info(json.dumps({"attempt": attempt, "status": 200, "sleep_ms": 0, "request_id": request_id}))
+            return resp
+        except Exception as exc:
+            status = getattr(getattr(exc, "response", None), "status_code", None) or getattr(exc, "code", None)
+            retry_after = None
+            if hasattr(exc, "response") and getattr(exc, "response", None):
+                retry_after = exc.response.headers.get("Retry-After")
+            sleep = min(2 ** (attempt - 1) + random.random(), 60)
+            if retry_after:
+                try:
+                    sleep = max(sleep, float(retry_after))
+                except ValueError:
+                    pass
+            log.info(json.dumps({"attempt": attempt, "status": status, "sleep_ms": int(sleep * 1000), "request_id": request_id}))
+            if attempt == GA4_MAX_RETRIES:
+                raise
+            time.sleep(sleep)
+
 # ------------------------------ Endpoints ------------------------------------
 @app.get("/", response_class=PlainTextResponse)
 def root() -> str:
     return "Dash Marketing API is up. See /docs for OpenAPI."
 
-@app.get("/health", response_class=PlainTextResponse)
-def health() -> str:
-    return "ok"
+@app.get("/health")
+def health():
+    return {"status": "ok"}
 
 @app.get("/version")
 def version():
     return {"version": app.version}
 
+class ExportarParams(BaseModel):
+    start: str = Field(..., description="YYYY-MM-DD", alias="from")
+    end: str = Field(..., description="YYYY-MM-DD", alias="to")
+    page_size: int = Field(1000, ge=1, alias="pageSize", description="Rows per page")
+    max_pages: int = Field(10000, ge=1, alias="maxPages", description="Safety cap")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 @app.get("/exportar")
-def exportar_datos(
-    start: str = Query(..., description="YYYY-MM-DD"),
-    end: str = Query(..., description="YYYY-MM-DD"),
-    page_size: int = Query(8000, ge=1000, le=25000, description="Rows per page (tune for memory)"),
-    max_pages: int = Query(200, ge=1, le=2000, description="Safety cap"),
-):
-    """
-    Exporta con streaming para no usar memoria: emite {"rows":[ ... ], meta...}
-    """
-    s_iso, e_iso = _clamp_dates(start, end)
+def exportar_datos(request: Request, params: ExportarParams = Depends()):
+    """Exporta con streaming para no usar memoria: emite {"rows":[ ... ], meta...}"""
+    s_iso, e_iso = _clamp_dates(params.start, params.end)
+    page_size = params.page_size
+    max_pages = params.max_pages
+    rid = getattr(request.state, "request_id", str(uuid.uuid4()))
     log.info(f"/exportar start={s_iso} end={e_iso} page_size={page_size} max_pages={max_pages}")
 
     client = _ga4_client()
     dims = _dims()
     mets = _mets()
 
+
+    effective_limit = min(page_size, 100000)
     req = RunReportRequest(
         property=f"properties/{PROPERTY_ID}",
         date_ranges=[DateRange(start_date=s_iso, end_date=e_iso)],
         dimensions=dims,
         metrics=mets,
         order_bys=_stable_order(),
-        limit=page_size,
-        offset=0,
+        limit=effective_limit,
     )
 
     pages = 0
@@ -174,8 +236,12 @@ def exportar_datos(
         nonlocal pages, total_rows_reported, sum_sessions, sum_users, sum_views, sum_conv, sum_rev
         yield b'{"rows":['
         first = True
+        page_token: Optional[str] = None
+        offset = 0
         while True:
-            resp = client.run_report(req)
+            req.page_token = page_token
+            req.offset = offset
+            resp = _run_report(client, req, rid)
             if total_rows_reported is None:
                 total_rows_reported = getattr(resp, "row_count", None)
             batch_count = 0
@@ -199,18 +265,28 @@ def exportar_datos(
                 break
 
             pages += 1
-            if total_rows_reported is not None and req.offset + batch_count >= total_rows_reported:
-                req.offset += batch_count
-                break
-            if pages >= max_pages:
-                log.warning("Reached max_pages cap; streaming will end early.")
-                req.offset += batch_count
+            page_token = getattr(resp, "next_page_token", None)
+            if page_token:
+                offset = 0
+            else:
+                offset += batch_count
+            if (total_rows_reported is not None and offset >= total_rows_reported) or pages >= max_pages:
+                if pages >= max_pages:
+                    log.warning("Reached max_pages cap; streaming will end early.")
                 break
 
-            req.offset += batch_count
             time.sleep(0.12)
 
         yield b"],"
+
+        partial = False
+        reason: Optional[str] = None
+        if pages >= max_pages:
+            partial = True
+            reason = "max_pages"
+        elif total_rows_reported is not None and offset < (total_rows_reported or 0):
+            partial = True
+            reason = "ga4_limit"
 
         agg = _agg_totals(client, s_iso, e_iso)
         diff = {
@@ -225,9 +301,7 @@ def exportar_datos(
             "start": s_iso,
             "end": e_iso,
             "pages": pages,
-            "truncated": (pages >= max_pages) or (
-                total_rows_reported is not None and req.offset < total_rows_reported
-            ),
+            "partial": partial,
             "audit": {
                 "detail_totals": {
                     "sessions": sum_sessions,
@@ -240,29 +314,33 @@ def exportar_datos(
                 "diff_pct": diff,
                 "rowCount": total_rows_reported,
                 "pages": pages,
-                "truncated": (pages >= max_pages) or (
-                    total_rows_reported is not None and req.offset < total_rows_reported
-                ),
+                "partial": partial,
             },
         }
+        if reason:
+            body_tail["reason"] = reason
+            body_tail["audit"]["reason"] = reason
         yield _dumps(body_tail)
         yield b"}"
 
     return StreamingResponse(_gen(), media_type="application/json")
 
+class ExportarMensualParams(BaseModel):
+    start: str = Field(..., description="YYYY-MM-DD")
+    end: str = Field(..., description="YYYY-MM-DD")
+    page_size: int = Field(8000, ge=1000, le=25000)
+    sleep_ms: int = Field(120, ge=0, le=2000, description="Backoff ms")
+
+
 @app.get("/exportar_mensual")
-def exportar_mensual(
-    start: str = Query(..., description="YYYY-MM-DD"),
-    end: str = Query(..., description="YYYY-MM-DD"),
-    page_size: int = Query(8000, ge=1000, le=25000),
-    sleep_ms: int = Query(120, ge=0, le=2000, description="Backoff ms"),
-):
-    """
-    Streaming por meses para rangos grandes. No acumula filas en memoria.
-    """
-    s_iso, e_iso = _clamp_dates(start, end)
+def exportar_mensual(request: Request, params: ExportarMensualParams = Depends()):
+    """Streaming por meses para rangos grandes. No acumula filas en memoria."""
+    s_iso, e_iso = _clamp_dates(params.start, params.end)
     s = _parse_date(s_iso)
     e = _parse_date(e_iso)
+    page_size = params.page_size
+    sleep_ms = params.sleep_ms
+    rid = getattr(request.state, "request_id", str(uuid.uuid4()))
     log.info(f"/exportar_mensual start={s_iso} end={e_iso} page_size={page_size}")
 
     client = _ga4_client()
@@ -287,18 +365,19 @@ def exportar_mensual(
             if m_start < s: m_start = s
             if m_start > m_end: continue
 
+            effective_limit = min(page_size, 100000)
             req = RunReportRequest(
                 property=f"properties/{PROPERTY_ID}",
                 date_ranges=[DateRange(start_date=m_start.isoformat(), end_date=m_end.isoformat())],
                 dimensions=dims,
                 metrics=mets,
                 order_bys=_stable_order(),
-                limit=page_size,
+                limit=effective_limit,
                 offset=0,
             )
 
             while True:
-                resp = client.run_report(req)
+                resp = _run_report(client, req, rid)
                 batch_count = 0
                 for r in resp.rows:
                     d = _row_to_dict(r, dims, mets)
@@ -344,7 +423,7 @@ def exportar_mensual(
             "start": s_iso,
             "end": e_iso,
             "pages": pages_total,
-            "truncated": False,
+            "partial": False,
             "audit": {
                 "detail_totals": {
                     "sessions": sum_sessions,
@@ -357,7 +436,7 @@ def exportar_mensual(
                 "diff_pct": diff,
                 "rowCount": None,
                 "pages": pages_total,
-                "truncated": False,
+                "partial": False,
             },
         }
         yield _dumps(tail)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    e2e: end-to-end tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
-fastapi
-uvicorn
-pandas
+fastapi==0.111.0
+uvicorn==0.30.1
+pandas==2.2.2
 google-analytics-data==0.18.19
 google-auth==2.27.0
-google-auth-oauthlib
+google-auth-oauthlib==1.1.0
 google-ads==22.0.0
-pydantic==2.11.7  # Asegúrate de tener la versión correcta de Pydantic
-grpcio==1.74.0  # Esto es necesario para las conexiones de gRPC, como Google Ads API
-google-api-core==2.25.1  # Para Google API en general
-protobuf==4.25.8  # Para la serialización de mensajes, necesaria para gRPC
+pydantic==2.11.7
+grpcio==1.74.0
+google-api-core==2.25.1
+protobuf==4.25.8
+tenacity==8.2.3
+python-dotenv==1.0.1
+requests==2.31.0
+httpx==0.27.0

--- a/scripts/prod_probe.py
+++ b/scripts/prod_probe.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import time
+import datetime as dt
+import requests
+import json
+
+BASE_URL = os.environ.get("BASE_URL", "https://dashmarketing.onrender.com").rstrip("/")
+NO_PROXY_HOSTS = os.environ.get("NO_PROXY", "")
+DEFAULT_NO_PROXY = "localhost,127.0.0.1,.onrender.com"
+if DEFAULT_NO_PROXY not in NO_PROXY_HOSTS:
+    os.environ["NO_PROXY"] = (NO_PROXY_HOSTS + "," if NO_PROXY_HOSTS else "") + DEFAULT_NO_PROXY
+
+
+def _session() -> requests.Session:
+    s = requests.Session()
+    s.trust_env = False  # ignora proxies del sistema
+    return s
+
+
+def main() -> int:
+    start = (dt.date.today() - dt.timedelta(days=30)).isoformat()
+    end = dt.date.today().isoformat()
+    t0 = time.time()
+    s = _session()
+    resp = s.get(f"{BASE_URL}/health", timeout=10, proxies={"http": None, "https": None})
+    if resp.status_code != 200 or resp.json() != {"status": "ok"}:
+        print("health check failed", file=sys.stderr)
+        return 1
+    resp = s.get(
+        f"{BASE_URL}/exportar",
+        params={"from": start, "to": end, "pageSize": 1000, "maxPages": 10000},
+        timeout=60,
+        proxies={"http": None, "https": None},
+    )
+    duration = time.time() - t0
+    if resp.status_code != 200:
+        print("exportar status", resp.status_code, file=sys.stderr)
+        return 1
+    data = resp.json()
+    rows = data.get("rows", [])
+    if data.get("partial") or not rows:
+        print("partial or empty", file=sys.stderr)
+        return 1
+    print(json.dumps({"rows": len(rows), "duration_ms": int(duration * 1000)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,0 +1,4 @@
+from prod_probe import main
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,34 @@
+import os
+import datetime as dt
+import pytest
+import requests
+
+BASE_URL = os.getenv("BASE_URL", "https://dashmarketing.onrender.com").rstrip("/")
+
+
+def _session() -> requests.Session:
+    s = requests.Session()
+    s.trust_env = False  # ignora proxies del sistema
+    return s
+
+
+@pytest.mark.e2e
+def test_exportar() -> None:
+    s = _session()
+    r = s.get(f"{BASE_URL}/health", timeout=10, proxies={"http": None, "https": None})
+    r.raise_for_status()
+    assert r.json() == {"status": "ok"}
+
+    start = (dt.date.today() - dt.timedelta(days=30)).isoformat()
+    end = dt.date.today().isoformat()
+
+    r = s.get(
+        f"{BASE_URL}/exportar",
+        params={"from": start, "to": end, "pageSize": 1000, "maxPages": 10000},
+        timeout=60,
+        proxies={"http": None, "https": None},
+    )
+    r.raise_for_status()
+    data = r.json()
+    assert not data.get("partial")
+    assert len(data.get("rows", [])) > 0


### PR DESCRIPTION
## Summary
- load config from .env and expose CORS origins for production frontends
- add retries with backoff and partial checks for GA4 pagination
- document Render deployment and provide Power BI sample query
- limit probe and tests to last 30 days

## Testing
- `python scripts/prod_probe.py` *(fails: Network is unreachable)*
- `python scripts/smoke_test.py` *(fails: Network is unreachable)*
- `pytest -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2cd5c5c08332a1ddf9921d1aaaae